### PR TITLE
Add long-held HTTP request support to LUD21 verify

### DIFF
--- a/21.md
+++ b/21.md
@@ -53,3 +53,8 @@ or
   "reason": "Not found"
 }
 ```
+
+## Optional Long-Held HTTP Mode
+
+Services MAY support keeping the HTTP connection open until payment completion by accepting a `wait` parameter without a value, e.g. in the above example the URL would become `https://example.com/verify/894e7f7e...?wait`. The request should return the response when the payment is settled or expires whichever comes first. Clients specifying the `?wait` flag MUST be able to gracefully deal with earlier, non-final responses where `"settled": false` if the server doesn't support the long-held HTTP mode or closed connections due to server timeouts.
+


### PR DESCRIPTION
Polling is an antipattern in most cases, it increases latency for clients and server load, yet it's the only way to use LNURL verify aka LUD21 right now. When e.g. building a PoS using LUD21 one has to poll at least every second to achieve reasonably low latency.

Long-polling fixes this.