### PR TITLE
LUD-16: add optional default identifier shorthand

### DIFF
--- a/16.md
+++ b/16.md
@@ -13,6 +13,16 @@ Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.
 
 The response from `SERVICE` then MUST be the same as in [LUD-06](06.md), step 3, and the flow is the same.
 
+### Default identifier
+
+A `SERVICE` MAY offer a default internet identifier for a domain by using `_` as the `<username>`.
+
+Upon seeing an address in the format `@<domainname>`, a `WALLET` MAY treat it as shorthand for `_@<domainname>` and make a GET request to the `https://<domain>/.well-known/lnurlp/_` endpoint if `domain` is clearnet or `http://<domain>/.well-known/lnurlp/_` if `domain` is onion. For example, if the address is `@bitcoin.org`, the request is to be made to `https://bitcoin.org/.well-known/lnurlp/_`.
+
+This shorthand is optional. A `WALLET` that does not implement it MAY reject `@<domainname>` as an invalid internet identifier, and a `SERVICE` that does not offer a default identifier MAY return an error or 404 for `/.well-known/lnurlp/_`. Existing `<username>@<domainname>` identifiers MUST continue to resolve as specified above.
+
+If a `SERVICE` returns metadata for a default identifier, it SHOULD use `_@<domainname>` as the canonical `text/identifier` value.
+
 If providing such a scheme, `SERVICE` MUST add to the `metadata` JSON array either a `text/email` entry or a `text/identifier` entry, as in examples below:
 
 ```


### PR DESCRIPTION
## Motivation

Lightning Address works well for hosted services, but personal domains often end up using placeholder local parts like `me@domain`, `pay@domain`, or `ln@domain` even when the domain itself is the intended identifier. This came up in andrerfneves/lightning-address#28.

## Proposal

This extends LUD-16 with an entirely optional default identifier convention:

- services MAY expose `_@domain` as the canonical default identifier
- wallets MAY accept `@domain` as shorthand for `_@domain`
- resolution uses the existing LUD-16 endpoint shape: `/.well-known/lnurlp/_`
- wallets and services that do not implement the shorthand remain fully compatible

This avoids introducing a new endpoint shape and keeps metadata aligned with the existing LUD-16 `user@site.com` identifier format.

## Testing

Docs-only spec change; no tests run.