### PR TITLE
LUD-25: allow a persistent SERVICE signing key

### DIFF
--- a/25.md
+++ b/25.md
@@ -176,14 +176,13 @@ A bearer note as defined above is an opaque secret: an offline recipient has no 
  {
    "tag": "withdrawRequest",
    ...
-+  "mintPubkey": string, // 33-byte compressed secp256k1 pubkey, hex
-+  "previousPubkeys": string[] // earlier mintPubkeys; present iff the key has rotated
++  "mintPubkey": string // 33-byte compressed secp256k1 pubkey, hex
  }
 ```
 
-`SERVICE` MUST rotate `mintPubkey` only deliberately. After a rotation it MUST publish every earlier `mintPubkey` under which a note may still circulate in `previousPubkeys`, for at least as long as it remembers notes and burns signed under that key. Old private keys need not be retained: verifying an existing signature needs only the public key, and new notes are signed only by the current key.
+`SERVICE` SHOULD NOT rotate `mintPubkey`. A rotation puts no note at risk, `SERVICE` authenticates a note by `sha256(k1)` and never by its signature, but it does end offline verification for every note signed under the old key. A holder restores verifiability by rotating such a note once, which re-signs it under the current key.
 
-`WALLET` MUST pin the accepted `mintPubkey` and `previousPubkeys` to the full `SERVICE` origin. A newly advertised `mintPubkey` MUST NOT silently replace a pinned one. `WALLET` MUST require explicit holder approval unless the change is authenticated by a separate continuity mechanism. Merely listing the old public key in an unsigned response preserves verification of old notes but does not prove that the old key authorised the new one.
+`WALLET` MUST pin the accepted `mintPubkey` to the full `SERVICE` origin. A newly advertised `mintPubkey` MUST NOT silently replace a pinned one, `WALLET` MUST require explicit holder approval.
 
 Signatures are only ever delivered in the `withdrawSuccessResponse` of a rotate, split or merge, the informational endpoint never returns one. A `WALLET` that wants a mint-signed certificate for a note that lacks one (e.g. a freshly minted note, or one received from a third party) obtains it by rotating the note once (see the minting diagram).
 
@@ -198,7 +197,7 @@ digest  = sha256(sha256("Lightning Signed Message:" || message))
 
 A `SERVICE` using its Lightning node identity MAY obtain the raw signature via that node's `signmessage` API (per [LUD-13](13.md)), then reorder its 65 bytes from `signmessage`'s recovery-id-leading convention into `r ‖ s ‖ recovery-id`, the same trailing-recovery-id layout raw BOLT-11 signatures already use elsewhere in this document, before hex-encoding it as `sig`. A `SERVICE` using a dedicated key signs the same digest directly and emits the same wire layout.
 
-To verify offline, a `WALLET` recomputes `digest` and recovers the public key from `(digest, signature)`, comparing it to the pinned current and previous keys it has on record for that mint. A match proves the note was issued by that mint for that amount under the matched key.
+To verify offline, a `WALLET` recomputes `digest` and recovers the public key from `(digest, signature)`, comparing it to the `mintPubkey` it has pinned for that mint. A match proves the note was issued by that mint for that amount.
 
 The `withdrawSuccessResponse` is extended:
 

--- a/25.md
+++ b/25.md
@@ -170,15 +170,20 @@ A `WALLET` that does not implement `LNURLcash` treats a received note as any oth
 
 A bearer note as defined above is an opaque secret: an offline recipient has no way to tell whether it was ever issued, by whom, or for how much. `SERVICE` MUST make its notes offline-verifiable by signing them.
 
-`SERVICE` publishes its signing key as `mintPubkey` (33-byte compressed secp256k1 public key, hex) in its `withdrawRequest` JSON response. It MUST be the node id `SERVICE` signs its BOLT-11 invoices with, so that freshly minted and rotated notes verify against the same identity - obtained the same way [LUD-13](13.md) already relies on a Lightning node's own `signmessage` API rather than a separate keypair, `SERVICE` MAY sign notes with that same call against its own node, needing no key management beyond what minting/melting already require. `WALLET` paying the invoice already decodes it to pay it, and can recover `SERVICE`'s node id directly from the invoice's own recoverable signature (see below), `mintPubkey` only needs publishing where there is no invoice to recover it from, i.e. at the withdraw LNURL (Minting a bearer note from a payRequest), whose discovery response and per-note informational GETs both carry it.
+`SERVICE` publishes its signing key as `mintPubkey` (33-byte compressed secp256k1 public key, hex) in its `withdrawRequest` JSON response. `mintPubkey` MUST be a stable key controlled by `SERVICE`. It SHOULD be the funding node identity when that backend exposes a compatible `signmessage` API, because a `WALLET` paying a BOLT-11 invoice can recover the node id from the invoice's own signature and corroborate the same identity without another trust root. A `SERVICE` whose backend cannot produce compatible signatures MAY instead use a dedicated signing key. A dedicated key MUST be persisted securely and MUST NOT be generated anew when `SERVICE` restarts. In that case offline verification proves issuance by the pinned `SERVICE` key, not by the Lightning node that funded the mint.
 
 ```diff
  {
    "tag": "withdrawRequest",
    ...
-+  "mintPubkey": string // 33-byte compressed secp256k1 pubkey, hex
++  "mintPubkey": string, // 33-byte compressed secp256k1 pubkey, hex
++  "previousPubkeys": string[] // earlier mintPubkeys; present iff the key has rotated
  }
 ```
+
+`SERVICE` MUST rotate `mintPubkey` only deliberately. After a rotation it MUST publish every earlier `mintPubkey` under which a note may still circulate in `previousPubkeys`, for at least as long as it remembers notes and burns signed under that key. Old private keys need not be retained: verifying an existing signature needs only the public key, and new notes are signed only by the current key.
+
+`WALLET` MUST pin the accepted `mintPubkey` and `previousPubkeys` to the full `SERVICE` origin. A newly advertised `mintPubkey` MUST NOT silently replace a pinned one. `WALLET` MUST require explicit holder approval unless the change is authenticated by a separate continuity mechanism. Merely listing the old public key in an unsigned response preserves verification of old notes but does not prove that the old key authorised the new one.
 
 Signatures are only ever delivered in the `withdrawSuccessResponse` of a rotate, split or merge, the informational endpoint never returns one. A `WALLET` that wants a mint-signed certificate for a note that lacks one (e.g. a freshly minted note, or one received from a third party) obtains it by rotating the note once (see the minting diagram).
 
@@ -191,9 +196,9 @@ digest  = sha256(sha256("Lightning Signed Message:" || message))
 
 `hex(sha256(k1))` is exactly the `h` (or `h2`) `WALLET` supplied on the redeem callback, `SERVICE` uses it verbatim and never needs to hash a raw secret to produce this signature.
 
-A Lightning node's own `signmessage` API already applies internally (per [LUD-13](13.md)); `SERVICE` MAY obtain the raw signature via that same call against its own node, then reorder its 65 bytes from `signmessage`'s recovery-id-leading convention into `r ‖ s ‖ recovery-id`, the same trailing-recovery-id layout raw BOLT-11 signatures already use elsewhere in this document, before hex-encoding it as `sig`.
+A `SERVICE` using its Lightning node identity MAY obtain the raw signature via that node's `signmessage` API (per [LUD-13](13.md)), then reorder its 65 bytes from `signmessage`'s recovery-id-leading convention into `r ‖ s ‖ recovery-id`, the same trailing-recovery-id layout raw BOLT-11 signatures already use elsewhere in this document, before hex-encoding it as `sig`. A `SERVICE` using a dedicated key signs the same digest directly and emits the same wire layout.
 
-To verify offline, a `WALLET` recomputes `digest` and recovers the public key from `(digest, signature)`, comparing it to the `mintPubkey` it has on record for that mint. A match proves the note was issued by that mint for that amount.
+To verify offline, a `WALLET` recomputes `digest` and recovers the public key from `(digest, signature)`, comparing it to the pinned current and previous keys it has on record for that mint. A match proves the note was issued by that mint for that amount under the matched key.
 
 The `withdrawSuccessResponse` is extended:
 


### PR DESCRIPTION
## Why

Offline verification is now mandatory for a SERVICE, which I think is right.  Requiring `mintPubkey` to be the funding node identity makes that impossible for a backend which can fund the mint but exposes no compatible `signmessage` API, such as Spark.  Making signatures optional again would remove the property we actually need.

## What

- keep note signatures mandatory
- require `mintPubkey` to be stable, persistent and controlled by SERVICE
- prefer the funding node identity where compatible signing exists
- allow a dedicated SERVICE key where it does not
- require wallets to pin the key by full SERVICE origin and never replace a pin silently

## Trust boundary

A dedicated key cannot be corroborated from the BOLT-11 invoice.  Offline verification then proves issuance by the pinned SERVICE key, not by the funding node.  The text says that directly.

Rotation is a SHOULD NOT, with no key history.  SERVICE authenticates a note by `sha256(k1)` and never by its signature, so a rotation puts no funds at risk, only the offline attestation, and the spec's existing repair path applies: rotating such a note once re-signs it under the current key.  A published history would also have got the urgent case backwards, since the rotation that needs to happen fast is a leaked key.

## Implementation impact

LND and CLN-backed services can keep using the node identity.  A Spark-backed reference mint can load a persistent local key and produce the same signature wire format.

This PR targets the existing `lnurlcash` branch behind #301.  It does not merge or change the `luds` base branch directly.  Documentation-only change; `git diff --check` passes.
